### PR TITLE
Fix permission denied error; missing share/php-build/after-install.d directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .vagrant
 tmp/
 var/
+
+share/php-build/before-install.d/*
+!share/php-build/before-install.d/.empty
+
+share/php-build/after-install.d/*
 !share/php-build/after-install.d/.empty
-share/php-build/after-install.d


### PR DESCRIPTION
Error:

    mkdir: cannot create directory /usr/local/bin/../share/php-build/after-install.d': Permission denied

This happens when for example the user installs php-build into a directory that
requires sudo privileges and then tries to run php-build as regular user e.g.
installing php into home directory.