### PR TITLE
Fix '--enable-intl' problem when configuring on osx php5.3

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -588,6 +588,25 @@ $CONFIGURE_OPTIONS"
 ! INSTALL_IT = \$(mkinstalldirs) '$PREFIX/libexec/apache2' && \$(mkinstalldirs) '\$(INSTALL_ROOT)/private/etc/apache2' && /usr/sbin/apxs -S LIBEXECDIR='$PREFIX/libexec/apache2' -S SYSCONFDIR='\$(INSTALL_ROOT)/private/etc/apache2' -i -a -n php5 libs/libphp5.so
 EOF
 
+    # Fix --enable-intl problem on osx php5.3
+    if [ is_osx -a `echo $(pwd) | grep '5.3'` ]; then
+      for option in $CONFIGURE_OPTIONS; do
+        case "$option" in
+          "--enable-intl"*)
+            cat <<EOF | patch -N -p0 -s || true
+--- Makefile	2014-01-14 17:47:58.000000000 +0900
++++ Makefile.modified	2014-01-14 17:51:09.000000000 +0900
+@@ -95,3 +95,3 @@
+ EXTRA_LDFLAGS_PROGRAM = -L/usr/local/Cellar/libxml2/2.9.1/lib -L/usr/local/opt/openssl/lib -L/usr/local/opt/pcre/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/jpeg/lib -L/usr/X11/lib -L/usr/local/opt/freetype/lib -L/usr/local/Cellar/icu4c/52.1/lib -L/usr/local/opt/mcrypt/lib
+-EXTRA_LIBS = -lexslt -lresolv -ledit -lncurses -lmcrypt -lltdl -liconv -liconv -lfreetype -lpng -lz -ljpeg -lcurl -lz -lpcre -lcrypto -lssl -lcrypto -lm -lxml2 -lz -liconv -lm -lcurl -lxml2 -lz -liconv -lm -lm -licui18n -licuuc -licudata -lm -licuio -lxml2 -lz -liconv -lm -lxml2 -lz -liconv -lm -lxml2 -lz -liconv -lm -lxml2 -lz -liconv -lm -lxml2 -lz -liconv -lm -lxml2 -lxslt
++EXTRA_LIBS = -lexslt -lresolv -ledit -lncurses -lmcrypt -lltdl -liconv -liconv -lfreetype -lpng -lz -ljpeg -lcurl -lz -lpcre -lcrypto -lssl -lcrypto -lm -lxml2 -lz -liconv -lm -lcurl -lxml2 -lz -liconv -lm -lm -licui18n -licuuc -licudata -lm -licuio -lxml2 -lz -liconv -lm -lxml2 -lz -liconv -lm -lxml2 -lz -liconv -lm -lxml2 -lz -liconv -lm -lxml2 -lz -liconv -lm -lxml2 -lxslt -lstdc++
+ ZEND_EXTRA_LIBS =
+EOF
+            ;;
+        esac
+      done
+    fi
+
     cd "$backup_pwd"
 }
 


### PR DESCRIPTION
'make' command fails when you configure php5.3 with '--enable-intl' option on osx.
This is a patch for it.

http://www.spinics.net/lists/php-install/msg01707.html

    1 warning generated.
    Undefined symbols for architecture x86_64:
      "std::terminate()", referenced from:
          ___clang_call_terminate in msgformat_helpers.o
      "___cxa_begin_catch", referenced from:
          ___clang_call_terminate in msgformat_helpers.o
      "___gxx_personality_v0", referenced from:
          _umsg_format_helper in msgformat_helpers.o
          _umsg_parse_helper in msgformat_helpers.o
          Dwarf Exception Unwind Info (__eh_frame) in msgformat_helpers.o
    ld: symbol(s) not found for architecture x86_64
    clang: error: linker command failed with exit code 1 (use -v to see invocation)
    make: *** [libs/libphp5.bundle] Error 1