### PR TITLE
Fix 'CONFIGURE_OPTIONS' refering to default_configure_options

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -99,7 +99,7 @@ PHP_DEFAULT_INI="php.ini-production"
 # in PHP's source.
 #
 # These arguments are read from `share/php-build/default_configure_options`.
-CONFIGURE_OPTIONS=$(cat "$PHP_BUILD_ROOT/share/php-build/default_configure_options")
+CONFIGURE_OPTIONS=$(eval echo $(cat "$PHP_BUILD_ROOT/share/php-build/default_configure_options"))
 
 if [ -n "$PHP_BUILD_CONFIGURE_OPTS" ]; then
     CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS $PHP_BUILD_CONFIGURE_OPTS"


### PR DESCRIPTION
Enable writing variables in $PHP_BUILD_ROOT/share/php-build/default_configure_options.

i.e.
```
--with-apxs2=/usr/local/apache-httpd-2.4.7/bin/apxs
--enable-mbstring
--enable-intl
--with-icu-dir=$(brew --prefix icu4c)
--with-gettext=$(brew --prefix gettext)
...
```