### PR TITLE
Fix zend_extension directive in xdebug.ini by whether php 5.2 or not

### DIFF
--- a/share/php-build/plugins.d/xdebug.sh
+++ b/share/php-build/plugins.d/xdebug.sh
@@ -95,7 +95,13 @@ function _build_xdebug {
             conf_line_prefix=";"
         fi
 
-        echo "$conf_line_prefix zend_extension=\"$extension_dir/xdebug.so\"" > $xdebug_ini
+        # change zend_extension directive whether php 5.2 or not
+        if [ `echo "$PREFIX" | grep '5.2'` ]; then
+            echo "$conf_line_prefix zend_extension_ts=\"$extension_dir/xdebug.so\"" > $xdebug_ini
+        else
+            echo "$conf_line_prefix zend_extension=\"$extension_dir/xdebug.so\"" > $xdebug_ini
+        fi
+
         echo "$conf_line_prefix html_errors=on" >> $xdebug_ini
     fi
 


### PR DESCRIPTION
Fix 'zend_extension'  directive in xdebug.ini by whether you configure php 5.2 or not.
__
php5.2 (5.2.17 of php-build is Thread Safe version.)
```
zend_extension_ts=".../xdebug.so"
```
other (as it is)
```
zend_extension=".../xdebug.so"
```