### PR TITLE
Added bats test for patching the source code + some fixes

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -419,13 +419,11 @@ function build_package {
 # Apply patch files
 function apply_patches {
     local source_path=$1
-    local patches_dir=$PHP_BUILD_ROOT/share/php-build/patches
 
     if [ -n "$PATCH_FILES" ]; then
         log "Info" "Applying patches: $PATCH_FILES"
         for patch in $PATCH_FILES; do
-            local patch_file="$patches_dir/$patch"
-            patch -d "$source_path" -N -p1 -s < $patch_file || true
+            patch -d "$source_path" -N -p1 -s < $patch || true
         done
     fi
 }
@@ -530,10 +528,17 @@ function configure_option {
 #
 # Add a patch to internal patch list
 function patch_file {
+    local patches_dir="$PHP_BUILD_ROOT/share/php-build/patches"
+    local patch="$patches_dir/$1"
+
+    if [ -f "$1" ]; then
+        local patch="$1"
+    fi
+
     if [ -n "$PATCH_FILES" ]; then
-        PATCH_FILES="$PATCH_FILES $1"
+        PATCH_FILES="$PATCH_FILES $patch"
     else
-        PATCH_FILES="$1"
+        PATCH_FILES="$patch"
     fi
 }
 
@@ -791,9 +796,10 @@ fi
 
 DEFINITION_PATH="$(find_definition "$DEFINITION")"
 
+LOG_NAME="$(basename "$DEFINITION_PATH")"
 # Generate the Path for the build log.
 TIME="$(date "+%Y%m%d%H%M%S")"
-LOG_PATH="/tmp/php-build.$DEFINITION.$TIME.log"
+LOG_PATH="/tmp/php-build.$LOG_NAME.$TIME.log"
 
 # Redirect everything logged to STDERR (except messages by php-build itself)
 # to the Log file.

--- a/tests/patch.bats
+++ b/tests/patch.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+@test "Patches are applied" {
+    TIME="$(date "+%Y%m%d%H%M%S")"
+    PATCH_TEST_DIR="/tmp/php-build-test-patch-$TIME"
+    FILE_TO_PATCH="$PATCH_TEST_DIR/file_to_patch"
+
+    # create test directory
+    mkdir $PATCH_TEST_DIR
+
+    # definition file
+    echo -e "patch_file \"$PATCH_TEST_DIR/test.patch\"\napply_patches \"$PATCH_TEST_DIR\""\
+        > "$PATCH_TEST_DIR/definition_file"
+
+    # the file which should be patched
+    echo 'before patch' > "$FILE_TO_PATCH"
+
+    # create the patch file
+    echo -e "--- a/file_to_patch\n+++ b/file_to_patch\n@@ -1 +1 @@\n-before patch\n+patched\n"\
+        > "$PATCH_TEST_DIR/test.patch"
+
+    ./bin/php-build "$PATCH_TEST_DIR/definition_file" "$PATCH_TEST_DIR/build"
+
+    grep -e "patched" "$FILE_TO_PATCH"
+
+    rm -rf "$PATCH_TEST_DIR"
+}


### PR DESCRIPTION
Added a Bats test for patching the source code, like mentioned in #233.

This required some minor changes to the code:
1. Defining a full patch through `patch_file` was not possible
2. Passing a full path over cli to a definition file was, other then described in `usage`, not possible. The log file was tried to be created with the full path specified.