### PR TITLE
Generic system for installing PHP extensions

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -104,6 +104,8 @@ CONFIGURE_OPTIONS=$(cat "$PHP_BUILD_ROOT/share/php-build/default_configure_optio
 # Patches to be applied at the source
 PATCH_FILES=""
 
+[ -z "$PHPBUILD_INSTALL_EXTENSION" ] && PHPBUILD_INSTALL_EXTENSION=""
+
 if [ -n "$PHP_BUILD_CONFIGURE_OPTS" ]; then
     CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS $PHP_BUILD_CONFIGURE_OPTS"
 fi
@@ -426,6 +428,25 @@ function apply_patches {
             patch -d "$source_path" -N -p1 -s < $patch_file || true
         done
     fi
+}
+
+# Install extensions
+function install_extensions {
+    ## handle extensions that should be installed by defined environment variable
+    ## variable must be in the format: extension_name=version extension_name=version
+    for extension_def in $PHPBUILD_INSTALL_EXTENSION; do
+        local extension=$(echo $extension_def | cut -d"=" -f1)
+        local version=$(echo $extension_def | cut -d"=" -f2)
+        local first_char=$(echo $version | cut -c1 )
+
+        # if first character of version is an "@" it's meant to be a revision
+        if [ $first_char = "@" ]; then
+            local version=$(echo $version | cut -c"2-")
+            install_extension_source $extension "$version"
+        else
+            install_extension $extension $version
+        fi
+    done
 }
 
 # Definition commands
@@ -780,6 +801,10 @@ exec 4<> "$LOG_PATH"
 
 [ "$ENABLE_PEAR" = "1" ] && log Warning "Installing Pear alongside of Pyrus is still experimental."
 
+# Load extension plugin
+source "$PHP_BUILD_ROOT/share/php-build/extension/extension.sh"
+log Info "Loaded extension plugin"
+
 # Load all definition plugins. Plugins register functions
 # for use whithin definitions. See the xdebug and pyrus plugins for
 # examples.
@@ -804,6 +829,9 @@ trigger_after_install 2>&4
 if [ "$ENABLE_PEAR" = "1" ]; then
     pear_setup
 fi
+
+# Installed extensions defined by environment variable
+install_extensions 2>&4
 
 # Unbind the error handler.
 trap - ERR

--- a/share/php-build/extension/definition
+++ b/share/php-build/extension/definition
@@ -1,0 +1,8 @@
+"name","url-dist","url_source","source_cwd","configure_args","extension_type","after_install"
+"apc","http://pecl.php.net/get/APC-$version.tgz","git@git.php.net:/pecl/caching/apc.git",,"--enable-apc","extension",
+"apcu","http://pecl.php.net/get/apcu-$version.tgz","https://github.com/krakjoe/apcu.git",,,"extension",
+"imagick","http://pecl.php.net/get/imagick-$version.tgz","https://github.com/mkoppanen/imagick.git",,,"extension",
+"uprofiler",,"https://github.com/FriendsOfPHP/uprofiler.git","extension",,"extension","uprofiler_after_install"
+"xcache","http://xcache.lighttpd.net/pub/Releases/$version/xcache-$version.tar.gz",,,"--enable-xcache","extension",
+"xdebug","http://xdebug.org/files/xdebug-$version.tgz","git://github.com/xdebug/xdebug.git",,"--enable-xdebug","zend_extension","xdebug_after_install"
+"xhprof","http://pecl.php.net/get/xhprof-$version.tgz","git://github.com/facebook/xhprof.git",,,"extension","xhprof_after_install"

--- a/share/php-build/extension/definition
+++ b/share/php-build/extension/definition
@@ -1,7 +1,10 @@
 "name","url-dist","url_source","source_cwd","configure_args","extension_type","after_install"
 "apc","http://pecl.php.net/get/APC-$version.tgz","git@git.php.net:/pecl/caching/apc.git",,"--enable-apc","extension",
 "apcu","http://pecl.php.net/get/apcu-$version.tgz","https://github.com/krakjoe/apcu.git",,,"extension",
+"igbinary","http://pecl.php.net/get/igbinary-$version.tgz","https://github.com/igbinary/igbinary.git",,,"extension",
 "imagick","http://pecl.php.net/get/imagick-$version.tgz","https://github.com/mkoppanen/imagick.git",,,"extension",
+"memcache","http://pecl.php.net/get/memcache-$version.tgz","git@git.php.net:/pecl/caching/memcache.git",,,"extension",
+"memcached","http://pecl.php.net/get/memcached-$version.tgz","https://github.com/php-memcached-dev/php-memcached.git",,"--disable-memcached-sasl","extension",
 "uprofiler",,"https://github.com/FriendsOfPHP/uprofiler.git","extension",,"extension","uprofiler_after_install"
 "xcache","http://xcache.lighttpd.net/pub/Releases/$version/xcache-$version.tar.gz",,,"--enable-xcache","extension",
 "xdebug","http://xdebug.org/files/xdebug-$version.tgz","git://github.com/xdebug/xdebug.git",,"--enable-xdebug","zend_extension","xdebug_after_install"

--- a/share/php-build/extension/extension.sh
+++ b/share/php-build/extension/extension.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Plugin for php-build to install PHP extensions
+#
+
+function install_extension {
+    local extension="$1"
+    local version="$2"
+    local type="$3"
+    local database=$PHP_BUILD_ROOT/share/php-build/extension/definition
+
+    # set type to "dist" per default
+    [[ -z "$type" ]] && type="dist"
+
+    local extension_line=$(grep "\"$extension\"" $database)
+
+    if [ -n "$extension_line" ]; then
+        IFS=, read name url_dist url_source source_cwd configure_args \
+            extension_type after_install <<< "$(echo "$extension_line" | sed 's/\"//g')"
+
+        # install from distribution package
+        if [ $type = "dist" ]; then
+            log "$extension" "Installing version $version"
+
+            if [ -z "$version" ]; then
+                echo "No version given for extension \"$extension\"" >&3
+                return 1
+            fi
+
+            _download_extension $name $version $url_dist "$configure_args" \
+                $extension_type "$after_install"
+        else
+            log "$extension" "Installing from source"
+
+            _checkout_extension $name "$version" $url_source "$source_cwd" \
+                "$configure_args" $extension_type "$after_install"
+        fi
+    else
+        echo "No configuration found fo extension \"$extension\", skipping" >&3
+    fi
+}
+
+function install_extension_source {
+    local extension="$1"
+    local revision="$2"
+
+    install_extension $extension "$revision" "source"
+}
+
+function _download_extension {
+    local name=$1
+    local version=$2
+    local url=$3
+    local configure_args=$4
+    local extension_type=$5
+    local after_install=$6
+    local package_url=$(eval echo $url)
+    local package_name="$name-$version"
+
+     # We cache the tarballs for APC versions in `packages/`.
+    if [ ! -f "$TMP/packages/$name-$version.tgz" ]; then
+        http get "$package_url" > "$TMP/packages/$package_name.tgz"
+    fi
+
+    # Each tarball gets extracted to `source/apcu-$version`.
+    if [ -d "$TMP/source/$package_name" ]; then
+        rm -rf "$TMP/source/$package_name"
+    fi
+
+    tar -xzf "$TMP/packages/$package_name.tgz" -C "$TMP/source"
+
+    [[ -f "$TMP/source/package.xml" ]] && rm "$TMP/source/package.xml"
+    [[ -f "$TMP/source/package2.xml" ]] && rm "$TMP/source/package2.xml"
+
+    _build_extension "$TMP/source/$package_name" $name "" "$configure_args" \
+        $extension_type "$after_install"
+}
+
+function _checkout_extension {
+    local name=$1
+    local version="$2"
+    local url_source="$3"
+    local source_cwd="$4"
+    local configure_args="$5"
+    local extension_type="$6"
+    local after_install="$7"
+    local source_dir="$TMP/source/$name-master"
+
+    if [ -d "$source_dir" ] && [ -d "$source_dir/.git" ]; then
+        log "$name" "Updating $name from Git Master"
+        cd "$source_dir"
+        git pull origin master > /dev/null
+        cd "$cwd"
+    else
+        log "$name" "Fetching from Git Master"
+        git clone "$url_source" "$source_dir" > /dev/null
+    fi
+
+    if [ -n "$version" ]; then
+        log "$name" "Checkout specified revision: $version"
+        cd "$source_dir"
+        git reset --hard $revision
+        cd "$cwd"
+    fi
+
+    _build_extension "$source_dir" $name "$source_cwd" "$configure_args" \
+        $extension_type "$after_install"
+}
+
+function _build_extension {
+    local source_dir="$1"
+    local name=$2
+    local source_cwd="$3"
+    local configure_args=$4
+    local extension_type=$5
+    local after_install=$6
+    local cwd=$(pwd)
+
+    log "$name" "Compiling $name in $source_dir"
+
+    cd "$source_dir/$source_cwd"
+
+    {
+        $PREFIX/bin/phpize > /dev/null
+        "$(pwd)/configure" --with-php-config=$PREFIX/bin/php-config \
+            $configure_args > /dev/null
+
+        make > /dev/null
+	make install > /dev/null
+    } >&4 2>&1
+
+    local extension_home="$PREFIX/share/$name"
+
+    [ ! -d "$extension_home" ] && mkdir -p "$extension_home"
+
+    local extension_ini="$PREFIX/etc/conf.d/$name.ini"
+
+    if [ ! -f "$extension_ini" ]; then
+        log "$name" "Installing $name configuration in $extension_ini"
+
+        echo "$extension_type=\"$name.so\"" > $extension_ini
+    fi
+
+    if [ -n "$after_install" ]; then
+        # Zend extensions are not looked up in PHP's extension dir, so
+        # we need to find the absolute path for the extension_dir.
+        local extension_dir=$("$PREFIX/bin/php-config" --extension-dir)
+
+        $after_install "$source_dir" "$extension_ini" "$extension_type" "$extension_dir" "$extension_home"
+    fi
+
+    log "$name" "Cleaning up."
+    make clean > /dev/null
+
+    cd "$cwd" > /dev/null
+}

--- a/share/php-build/plugins.d/apc.sh
+++ b/share/php-build/plugins.d/apc.sh
@@ -1,69 +1,8 @@
-#!/usr/bin/env bash
-#
-# This shell scriplet is meant to be included by other shell scripts
+#!/usr/bin/env bash 	
+# 	
+# This shell scriplet is meant to be included by other shell scripts 	
 # to set up some variables and a few helper shell functions.
 
 function install_apc {
-    local version=$1
-    local package_url="http://pecl.php.net/get/APC-$version.tgz"
-
-    if [ -z "$version" ]; then
-        echo "install_APC: No Version given." >&3
-        return 1
-    fi
-
-    log "APC" "Downloading $package_url"
-
-    # We cache the tarballs for APC versions in `packages/`.
-    if [ ! -f "$TMP/packages/APC-$version.tgz" ]; then
-        wget -qP "$TMP/packages" "$package_url"
-    fi
-
-    # Each tarball gets extracted to `source/APC-$version`.
-    if [ -d "$TMP/source/APC-$version" ]; then
-        rm -rf "$TMP/source/APC-$version"
-    fi
-
-    tar -xzf "$TMP/packages/APC-$version.tgz" -C "$TMP/source"
-
-    [[ -f "$TMP/source/package.xml" ]] && rm "$TMP/source/package.xml"
-    [[ -f "$TMP/source/package2.xml" ]] && rm "$TMP/source/package2.xml"
-
-    _build_apc "$TMP/source/APC-$version"
-}
-
-function _build_apc {
-    local source_dir="$1"
-    local cwd=$(pwd)
-
-    log "APC" "Compiling in $source_dir"
-
-    cd "$source_dir"
-
-    {
-        $PREFIX/bin/phpize > /dev/null
-        "$(pwd)/configure" --enable-apc \
-        --with-php-config=$PREFIX/bin/php-config > /dev/null
-
-        make > /dev/null
-        make install > /dev/null
-    } >&4 2>&1
-
-    local apc_home="$PREFIX/share/apc"
-
-    [ ! -d "$apc_home" ] && mkdir -p "$apc_home"
-
-    local apc_ini="$PREFIX/etc/conf.d/apc.ini"
-
-    if [ ! -f "$apc_ini" ]; then
-        log "APC" "Installing APC configuration in $apc_ini"
-
-        echo "extension=\"apc.so\"" > $apc_ini
-
-    fi
-
-    log "APC" "Cleaning up."
-    make clean > /dev/null
-
-    cd "$cwd" > /dev/null
+    install_extension "apc" "$1"
 }

--- a/share/php-build/plugins.d/uprofiler.sh
+++ b/share/php-build/plugins.d/uprofiler.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+function uprofiler_after_install {
+    local source_dir=$1
+    local ini_file=$2
+    local extension_home=$5
+
+    cp -r "$source_dir/uprofiler_html" "$extension_home"
+    cp -r "$source_dir/uprofiler_lib" "$extension_home"
+
+    echo "uprofiler.output_dir=\"/var/tmp/uprofiler\"" >> $ini_file
+}

--- a/share/php-build/plugins.d/xdebug.sh
+++ b/share/php-build/plugins.d/xdebug.sh
@@ -5,104 +5,34 @@
 
 # PHP.next Development releases depend on current XDebug development snapshots
 function install_xdebug_master {
-    local source_dir="$TMP/source/xdebug-master"
-    local cwd=$(pwd)
-    local revision=$1
-
-    if [ -d "$source_dir" ] && [ -d "$source_dir/.git" ]; then
-        log "XDebug" "Updating XDebug from Git Master"
-        cd "$source_dir"
-        git pull origin master > /dev/null
-        cd "$cwd"
-    else
-        log "XDebug" "Fetching from Git Master"
-        git clone git://github.com/xdebug/xdebug.git "$source_dir" > /dev/null
-    fi
-
-    if [ -n "$revision" ]; then
-        log "XDebug" "Checkout specified revision: $revision"
-        cd "$source_dir"
-        git reset --hard $revision
-        cd "$cwd"
-    fi
-
-    _build_xdebug "$source_dir"
+    install_extension_source "xdebug" "$1"
 }
 
 # On the contrary, for stable PHP versions we need a stable XDebug version
 function install_xdebug {
-    local version=$1
-    local package_url="http://xdebug.org/files/xdebug-$version.tgz"
-
-    if [ -z "$version" ]; then
-        echo "install_xdebug: No Version given." >&3
-        return 1
-    fi
-
-    log "XDebug" "Downloading $package_url"
-
-    # We cache the tarballs for XDebug versions in `packages/`.
-    if [ ! -f "$TMP/packages/xdebug-$version.tgz" ]; then
-        http get "$package_url" > "$TMP/packages/xdebug-$version.tgz"
-    fi
-
-    # Each tarball gets extracted to `source/xdebug-$version`.
-    if [ -d "$TMP/source/xdebug-$version" ]; then
-        rm -rf "$TMP/source/xdebug-$version"
-    fi
-
-    tar -xzf "$TMP/packages/xdebug-$version.tgz" -C "$TMP/source"
-
-    [[ -f "$TMP/source/package.xml" ]] && rm "$TMP/source/package.xml"
-    [[ -f "$TMP/source/package2.xml" ]] && rm "$TMP/source/package2.xml"
-
-    _build_xdebug "$TMP/source/xdebug-$version"
+    install_extension "xdebug" "$1"
 }
 
-function _build_xdebug {
-    local source_dir="$1"
-    local cwd=$(pwd)
-
-    log "XDebug" "Compiling in $source_dir"
-
-    cd "$source_dir"
-
-    {
-        $PREFIX/bin/phpize > /dev/null
-        "$(pwd)/configure" --enable-xdebug \
-        --with-php-config=$PREFIX/bin/php-config > /dev/null
-
-        make > /dev/null
-        make install > /dev/null
-    } >&4 2>&1
-
-    local xdebug_ini="$PREFIX/etc/conf.d/xdebug.ini"
-
-    # Zend extensions are not looked up in PHP's extension dir, so
-    # we need to find the absolute path for the extension_dir.
-    local extension_dir=$("$PREFIX/bin/php-config" --extension-dir)
+function xdebug_after_install {
+    local source_dir=$1
+    local ini_file=$2
+    local extension_type=$3
+    local extension_dir=$4
 
     if [ -z "$PHP_BUILD_XDEBUG_ENABLE" ]; then
         PHP_BUILD_XDEBUG_ENABLE=yes
     fi
 
-    if [ ! -f "$xdebug_ini" ]; then
-        log "XDebug" "Installing XDebug configuration in $xdebug_ini"
-
-        # Comment out the lines in the xdebug.ini when the env variable
-        # is set to something to "no"
-        local conf_line_prefix=
-        if [ "$PHP_BUILD_XDEBUG_ENABLE" == "off" ]; then
-            log "XDebug" "XDebug is commented out in $xdebug_ini. Remove the \";\" to enable it."
-            conf_line_prefix=";"
-        fi
-
-        echo "$conf_line_prefix zend_extension=\"$extension_dir/xdebug.so\"" > $xdebug_ini
-        echo "$conf_line_prefix html_errors=on" >> $xdebug_ini
+     # Comment out the lines in the xdebug.ini when the env variable
+    # is set to something to "no"
+    local conf_line_prefix=
+    if [ "$PHP_BUILD_XDEBUG_ENABLE" == "off" ]; then
+        log "XDebug" "XDebug is commented out in $xdebug_ini. Remove the \";\" to enable it."
+        conf_line_prefix=";"
     fi
 
-    log XDebug "Cleaning up."
-    make clean > /dev/null
-
-    cd "$cwd" > /dev/null
+    echo -n "$conf_line_prefix" > $ini_file
+    echo "$extension_type=\"$extension_dir/xdebug.so\"" >> $ini_file
+    echo -n "$conf_line_prefix" >> $ini_file
+    echo "html_errors=on" >> $ini_file
 }

--- a/share/php-build/plugins.d/xhprof.sh
+++ b/share/php-build/plugins.d/xhprof.sh
@@ -4,97 +4,13 @@
 # to set up some variables and a few helper shell functions.
 
 function install_xhprof_master {
-    local source_dir="$TMP/source/xhprof-master"
-    local cwd=$(pwd)
-    local revision=$1
-
-    if [ -d "$source_dir" ] && [ -d "$source_dir/.git" ]; then
-        log "xhprof" "Updating xhprof from Git Master"
-        cd "$source_dir"
-        git pull origin master > /dev/null
-        cd "$cwd"
-    else
-        log "xhprof" "Fetching from Git Master"
-        git clone git://github.com/facebook/xhprof.git "$source_dir" > /dev/null
-    fi
-
-    if [ -n "$revision" ]; then
-        log "xhprof" "Checkout specified revision: $revision"
-        cd "$source_dir"
-        git reset --hard $revision
-        cd "$cwd"
-    fi
-
-    _build_xhprof "$source_dir"
+    install_extension_source "xhprof" "$1"
 }
 
 function install_xhprof {
-    local version=$1
-    local package_url="http://pecl.php.net/get/xhprof-$version.tgz"
-
-    if [ -z "$version" ]; then
-        echo "install_xhprof: No Version given." >&3
-        return 1
-    fi
-
-    log "xhprof" "Downloading $package_url"
-
-    # We cache the tarballs for xhprof versions in `packages/`.
-    if [ ! -f "$TMP/packages/xhprof-$version.tgz" ]; then
-        wget -qP "$TMP/packages" "$package_url"
-    fi
-
-    # Each tarball gets extracted to `source/xhprof-$version`.
-    if [ -d "$TMP/source/xhprof-$version" ]; then
-        rm -rf "$TMP/source/xhprof-$version"
-    fi
-
-    tar -xzf "$TMP/packages/xhprof-$version.tgz" -C "$TMP/source"
-
-    [[ -f "$TMP/source/package.xml" ]] && rm "$TMP/source/package.xml"
-    [[ -f "$TMP/source/package2.xml" ]] && rm "$TMP/source/package2.xml"
-
-    _build_xhprof "$TMP/source/xhprof-$version"
+    install_extension xhprof "$1"
 }
 
-function _build_xhprof {
-    local source_dir="$1"
-    local cwd=$(pwd)
-
-    log "xhprof" "Compiling in $source_dir"
-
-    cd "$source_dir/extension"
-
-    {
-        $PREFIX/bin/phpize > /dev/null
-        "$(pwd)/configure" --with-php-config=$PREFIX/bin/php-config > /dev/null
-
-        make > /dev/null
-        make install > /dev/null
-    } >&4 2>&1
-
-    local xhprof_home="$PREFIX/share/xhprof"
-
-    [ ! -d "$xhprof_home" ] && mkdir -p "$xhprof_home"
-
-    # copy xhprof_html & xhprof_lib
-    cp -r "$source_dir/xhprof_html" "$xhprof_home"
-    cp -r "$source_dir/xhprof_lib" "$xhprof_home"
-
-    local xhprof_ini="$PREFIX/etc/conf.d/xhprof.ini"
-
-    local extension_dir=$("$PREFIX/bin/php" -r "echo ini_get('extension_dir');")
-
-    if [ ! -f "$xhprof_ini" ]; then
-        log "xhprof" "Installing xhprof configuration in $xhprof_ini"
-
-        echo "extension=\"$extension_dir/xhprof.so\"" > $xhprof_ini
-        echo "xhprof.output_dir=\"/var/tmp/xhprof\"" >> $xhprof_ini
-
-    fi
-
-    log "xhprof" "Cleaning up."
-    make clean > /dev/null
-
-    cd "$cwd" > /dev/null
+function xhprof_after_install {
+    echo "xhprof.output_dir=\"/var/tmp/xhprof\"" >> $2
 }


### PR DESCRIPTION
Added a generic system for installing PHP extensions from distribution package or from source.

* added definition file for data needed to compile extensions
* installation of every PHP extension uses same system
* added the following extensions:
  * apc
  * apcu
  * imagick
  * uprofiler
  * xcache
  * xdebug
  * xhprof
* definition files remain compatible
* added environment variable to install PHP extensions
* adding new extension just requires adding it to the definition file and optionally a callback to do some extra operations

**How to use environment variable**

Install apcu and imagick:
```
PHPBUILD_INSTALL_EXTENSION="apcu=4.0.7 imagick=3.1.2" ./php-build -i development <php-version> <destination>
```

Install an extension from source:
```
PHPBUILD_INSTALL_EXTENSION="uprofiler=@" ./php-build -i development <php-version> <destination>
```

Install an extension from source, but use specified revision:
```
PHPBUILD_INSTALL_EXTENSION="uprofiler=@851da15" ./php-build -i development <php-version> <destination>
```

This PR also fixes #221 #235 #236 #237 