### PR TITLE
Removed old php 5.5 definitions

### DIFF
--- a/share/php-build/definitions/5.5.0RC1
+++ b/share/php-build/definitions/5.5.0RC1
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/dsp/php-5.5.0RC1.tar.bz2"
-install_pyrus
-install_xdebug_master

--- a/share/php-build/definitions/5.5.0RC2
+++ b/share/php-build/definitions/5.5.0RC2
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/dsp/php-5.5.0RC2.tar.bz2"
-install_pyrus
-install_xdebug_master

--- a/share/php-build/definitions/5.5.0RC3
+++ b/share/php-build/definitions/5.5.0RC3
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/dsp/php-5.5.0RC3.tar.bz2"
-install_pyrus
-install_xdebug_master

--- a/share/php-build/definitions/5.5.0beta1
+++ b/share/php-build/definitions/5.5.0beta1
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/dsp/php-5.5.0beta1.tar.bz2"
-install_pyrus
-# install_xdebug_master

--- a/share/php-build/definitions/5.5.0beta2
+++ b/share/php-build/definitions/5.5.0beta2
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/dsp/php-5.5.0beta2.tar.bz2"
-install_pyrus
-# install_xdebug_master

--- a/share/php-build/definitions/5.5.0beta3
+++ b/share/php-build/definitions/5.5.0beta3
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/dsp/php-5.5.0beta3.tar.bz2"
-install_pyrus
-install_xdebug_master

--- a/share/php-build/definitions/5.5.0beta4
+++ b/share/php-build/definitions/5.5.0beta4
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/dsp/php-5.5.0beta4.tar.bz2"
-install_pyrus
-install_xdebug_master


### PR DESCRIPTION
I think it's pretty safe to remove these old definitions now. They're quite inconsistent with the rest of the definitions anyway because beta1 and beta2 don't have xdebug enabled, and beta3-rc3 are using xdebug master rather than a tagged 2.2 release.