### PR TITLE
Removed old php 5.6 alpha definitions

### DIFF
--- a/share/php-build/definitions/5.6.0alpha1
+++ b/share/php-build/definitions/5.6.0alpha1
@@ -1,4 +1,0 @@
-install_package "http://downloads.php.net/tyrael/php-5.6.0alpha1.tar.bz2"
-install_pyrus
-install_xdebug "2.2.7"
-enable_builtin_opcache

--- a/share/php-build/definitions/5.6.0alpha2
+++ b/share/php-build/definitions/5.6.0alpha2
@@ -1,4 +1,0 @@
-install_package "http://downloads.php.net/tyrael/php-5.6.0alpha2.tar.bz2"
-install_pyrus
-install_xdebug "2.2.7"
-enable_builtin_opcache

--- a/share/php-build/definitions/5.6.0alpha3
+++ b/share/php-build/definitions/5.6.0alpha3
@@ -1,4 +1,0 @@
-install_package "http://downloads.php.net/tyrael/php-5.6.0alpha3.tar.bz2"
-install_pyrus
-install_xdebug "2.2.7"
-enable_builtin_opcache


### PR DESCRIPTION
I think it's pretty safe to remove these old definitions now. Surely nobody is actually using them?