### PR TITLE
Remove Xdebug in the PHP master definition as it does not support PHP7

### DIFF
--- a/share/php-build/definitions/master
+++ b/share/php-build/definitions/master
@@ -1,4 +1,6 @@
 install_package_from_github master
 install_pyrus
-install_xdebug_master
+# Xdebug is not yet compatible with PHP 7 so it is disabled for now
+# TODO: uncomment this once support is added: http://bugs.xdebug.org/view.php?id=1109
+# install_xdebug_master
 enable_builtin_opcache


### PR DESCRIPTION
See the discussion in https://github.com/travis-ci/travis-ci/issues/2480#issuecomment-74901214