### PR TITLE
add 5.6.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
     - DEFINITION=5.4.37
     - DEFINITION=5.5.21
     - DEFINITION=5.6.5
+    - DEFINITION=5.6.6
 
 script: ./run-tests.sh $DEFINITION
 

--- a/share/php-build/definitions/5.6.6
+++ b/share/php-build/definitions/5.6.6
@@ -1,0 +1,4 @@
+install_package "http://php.net/distributions/php-5.6.6.tar.bz2"
+install_pyrus
+install_xdebug "2.2.7"
+enable_builtin_opcache


### PR DESCRIPTION
Hi,
i've added php 5.6.6 just by copy-pasting 5.6.5 and replacing the version-number.
xdebug is still @ 2.2.7

and by the way, thanks!